### PR TITLE
Fixed setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(name='d3py',
       author='Mike Dewar, Micha Gorelick and Adam Laiacano',
       author_email='md@bit.ly',
       url='https://github.com/mikedewar/D3py',
-      packages=['d3py']
+      packages=['d3py', 'd3py.geoms']
  )


### PR DESCRIPTION
setup.py was previously not explicitly installing the new geoms
submodule.  Quick fix!
