### PR TITLE
Adds python syntax highlighting to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,25 +39,27 @@ d3py aims to create really simple javascript source code wherever possible, so y
 
 An example session could like:
 
-	import d3py
-	import pandas
-	import numpy as np
+```python
+import d3py
+import pandas
+import numpy as np
 	
-	# some test data
-	T = 100
-	# this is a data frame with three columns (we only use 2)
-	df = pandas.DataFrame({
-	    "time" : range(T),
-	    "pressure": np.random.rand(T),
-	    "temp" : np.random.rand(T)
-	})
-	## build up a figure, ggplot2 style
-	# instantiate the figure object
-	fig = d3py.PandasFigure(df, name="basic_example", width=300, height=300) 
-	# add some red points
-	fig += d3py.geoms.Point(x="pressure", y="temp", fill="red")
-	# writes 3 files, starts up a server, then draws some beautiful points in Chrome
-	fig.show() 
+# some test data
+T = 100
+# this is a data frame with three columns (we only use 2)
+df = pandas.DataFrame({
+    "time" : range(T),
+    "pressure": np.random.rand(T),
+    "temp" : np.random.rand(T)
+})
+## build up a figure, ggplot2 style
+# instantiate the figure object
+fig = d3py.PandasFigure(df, name="basic_example", width=300, height=300) 
+# add some red points
+fig += d3py.geoms.Point(x="pressure", y="temp", fill="red")
+# writes 3 files, starts up a server, then draws some beautiful points in Chrome
+fig.show() 
+```
 
 Check out the examples in the folder for more functionality! Assuming everything is working OK, the examples should generate (something akin to) the following plots:
 


### PR DESCRIPTION
This PR adds syntax highlighting. Specifically, the markdown readme file it replaces

```
    # comment
    x = 1
    for i in range(x):
        x += 1
```

with

``````
```python
# comment
x = 1
for i in range(x):
    x += 1
```
``````
