### PR TITLE
docs: fix simple typo, sandard -> standard

### DIFF
--- a/d3py/figure.py
+++ b/d3py/figure.py
@@ -47,7 +47,7 @@ class Figure(object):
             Name of the font you'd like to use. See     
             http://www.google.com/webfonts for options
         logging: 
-            Logging via the sandard Python loggin library
+            Logging via the standard Python loggin library
         template: string
             HTML template for figure. Defaults to /d3py_template (Also, when 
             building your own HTML, please see the default template for 


### PR DESCRIPTION
There is a small typo in d3py/figure.py.

Should read `standard` rather than `sandard`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md